### PR TITLE
Update usage to use require("collections/map").CollectionsMap

### DIFF
--- a/collection/map.md
+++ b/collection/map.md
@@ -3,7 +3,7 @@
 name: Map
 
 usage: |
-    var Map = require("collections/map");
+    var Map = require("collections/map").CollectionsMap;
 
 names:
 -   Map()


### PR DESCRIPTION
Looks `require("collections/map")` returns JS's built-in Map type when available, which is not 100% compatible with Map in collections.js e.g., equals, hash parameters are not available.

So how about updating the usage to use `require("collections/map").CollectionsMap`, to match the rest of the documentation?