### PR TITLE
Updated order of text on change listener page

### DIFF
--- a/method/add-range-change-listener.md
+++ b/method/add-range-change-listener.md
@@ -39,9 +39,9 @@ as `splice(index, 1, value)`.
 Every time you push a value onto an array, it can be modeled as `splice(length,
 0, value)`.
 Every time you shift a value off an array, it cam be modeled as `splice(0, 1)`.
-Each of these changes can be communicated with a single message, `(plus, minus,
-index)`: the values removed after that index, the values that were added after
-that index, and the index itself, in that order.
+Each of these changes can be communicated with a single message, `(plus, minus, 
+index)`: the values added after that index, then the values that were removed 
+after that index, and the index, in that order.
 
 Range change listeners receive such messages synchronously, as the array
 changes.


### PR DESCRIPTION
There is a bug on https://github.com/montagejs/collections/issues/193 where its proposed to make this change.  I'm just doing the update as it was described.